### PR TITLE
Fix apply-tags pipeline validation errors

### DIFF
--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -298,6 +298,10 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
Add IMAGE_URL and IMAGE_DIGEST parameters to all apply-tags tasks in
Tekton pipelines to resolve validation failures.

https://github.com/openshift/bpfman/pull/209 bumps the
apply-tags parameters requirements. And catalogue builds have been
failing for more than a week.

https://issues.redhat.com/browse/KFLUXSPRT-3675
