### PR TITLE
Migrate source-build-oci-ta task to support 0.3 parameter changes

### DIFF
--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -157,7 +157,9 @@ spec:
   - name: build-source-image
     params:
     - name: BINARY_IMAGE
-      value: $(params.output-image)
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: BINARY_IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT


### PR DESCRIPTION
Update the multi-arch build pipeline to include the new
BINARY_IMAGE_DIGEST parameter required by the source-build-oci-ta task
version 0.3 migration. The pipeline now uses build-image-index task
results for both BINARY_IMAGE and BINARY_IMAGE_DIGEST parameters.

Migration reference: https://github.com/konflux-ci/build-definitions/blob/main/task/source-build-oci-ta/0.3/MIGRATION.md

Related: https://github.com/openshift/bpfman/pull/225.