### PR TITLE
Bypass hermetic builds to support Rust edition 2024

### DIFF
--- a/.tekton/ocp-bpfman-pull-request.yaml
+++ b/.tekton/ocp-bpfman-pull-request.yaml
@@ -32,6 +32,8 @@ spec:
     value: Containerfile.bpfman.openshift
   - name: path-context
     value: .
+  - name: hermetic
+    value: "false"
   - name: build-platforms
     value:
     - localhost

--- a/.tekton/ocp-bpfman-push.yaml
+++ b/.tekton/ocp-bpfman-push.yaml
@@ -30,6 +30,8 @@ spec:
     value: Containerfile.bpfman.openshift
   - name: path-context
     value: .
+  - name: hermetic
+    value: "false"
   - name: build-platforms
     value:
     - localhost

--- a/Containerfile.bpfman.openshift
+++ b/Containerfile.bpfman.openshift
@@ -4,10 +4,11 @@ ARG DNF_CMD="microdnf"
 WORKDIR /usr/src/bpfman
 COPY ./ /usr/src/bpfman
 
+# Install minimal dependencies and modern Rust via rustup
 RUN ${DNF_CMD} update -y \
-    && ${DNF_CMD} install -y gcc openssl-devel cmake clang\
+    && ${DNF_CMD} install -y gcc openssl-devel \
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.85.0 \
     && ${DNF_CMD} clean all
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Compile bpfman cli, bpfman-ns, and bpfman-rpc binaries


### PR DESCRIPTION
## Summary

UBI 9.6 does not have Rust edition 2024. We need edition 2024, so building non-hermetically and relying on external tools via rustup.

### Changes

- Install Rust 1.85.0 via rustup instead of system packages
- Set `hermetic: "false"` in pipeline configurations to allow network access