### PR TITLE
Add version sync tooling and build metadata labels

### DIFF
--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -109,6 +109,14 @@ spec:
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: IMAGE_APPEND_PLATFORM
       value: 'true'
+    - name: LABELS
+      value:
+      - io.openshift.build.commit.id=$(tasks.clone-repository.results.commit)
+      - io.openshift.build.commit.ref=$(params.revision)
+      - io.openshift.build.commit.date=$(tasks.clone-repository.results.commit-timestamp)
+      - io.openshift.build.source-location=$(params.git-url)
+      - vcs-ref=$(tasks.clone-repository.results.short-commit)
+      - vcs-url=$(tasks.clone-repository.results.url)
     runAfter:
     - prefetch-dependencies
     taskRef:

--- a/hack/openshift/Makefile
+++ b/hack/openshift/Makefile
@@ -1,0 +1,11 @@
+# Sync VERSION from Cargo.toml to all OpenShift Containerfiles. Run this
+# after merging from upstream or when VERSION changes in Cargo.toml.
+.PHONY: set-version
+set-version:
+	@echo "Syncing Cargo.toml VERSION to OpenShift Containerfiles..."
+	@./sync-version.sh
+
+.PHONY: help
+help:
+	@echo "Available targets:"
+	@echo "  set-version  - Sync VERSION from Cargo.toml to OpenShift Containerfiles"

--- a/hack/openshift/README.md
+++ b/hack/openshift/README.md
@@ -1,0 +1,17 @@
+# OpenShift Build Tools
+
+Tools for maintaining OpenShift-specific build artefacts.
+
+## Version Synchronisation
+
+Synchronise version labels in OpenShift Containerfiles with the upstream Cargo.toml:
+
+```bash
+make -C hack/openshift set-version
+```
+
+Run this after:
+- Merging from upstream when version changes
+- Updating version in Cargo.toml
+
+The script reads `version` from `[workspace.package]` in Cargo.toml and updates all `version=` labels in OpenShift-specific Containerfiles.

--- a/hack/openshift/sync-version.sh
+++ b/hack/openshift/sync-version.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+# Sync project version from Cargo.toml to all OpenShift
+# Containerfiles.
+
+set -e
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+
+cargo_toml="${repo_root}/Cargo.toml"
+
+containerfiles=(
+    "${repo_root}/Containerfile.bpfman.openshift"
+)
+
+if [ ! -f "$cargo_toml" ]; then
+    echo "Error: Cargo.toml file not found at $cargo_toml" >&2
+    exit 1
+fi
+
+# Extract version from Cargo.toml's [workspace.package] section. The
+# version line appears after [workspace.package] and before the next
+# section
+version=$(awk '
+    /^\[workspace\.package\]/ { in_section=1; next }
+    /^\[/ && in_section { exit }
+    in_section && /^version = / {
+        gsub(/version = "|"/, "")
+        print
+        exit
+    }
+' "$cargo_toml")
+
+if [ -z "$version" ]; then
+    echo "Error: Could not extract version from $cargo_toml" >&2
+    exit 1
+fi
+
+echo "Target VERSION: $version"
+
+any_updated=false
+
+for containerfile in "${containerfiles[@]}"; do
+    if [ ! -f "$containerfile" ]; then
+        echo "Warning: Containerfile not found at $containerfile, skipping..." >&2
+        continue
+    fi
+
+    current_version=$(grep -oP 'version="\K[^"]+' "$containerfile" | head -1)
+
+    if [ -z "$current_version" ]; then
+        echo "Error: No version label found in $containerfile" >&2
+        exit 1
+    fi
+
+    if [ "$current_version" = "$version" ]; then
+        echo "[OK] $(basename "$containerfile"): already in sync ($version)"
+    else
+        echo "[UPDATE] $(basename "$containerfile"): updating from $current_version to $version"
+
+        sed -i "s/version=\"[^\"]*\"/version=\"$version\"/" "$containerfile"
+
+        if grep -q 'release="' "$containerfile"; then
+            sed -i "s/release=\"[^\"]*\"/release=\"$version\"/" "$containerfile"
+        fi
+
+        any_updated=true
+    fi
+done
+
+if [ "$any_updated" = true ]; then
+    echo ""
+    echo "Updated Containerfiles with VERSION=$version"
+
+    if command -v git &> /dev/null; then
+        echo ""
+        echo "Changes made:"
+        git diff --stat "${containerfiles[@]}"
+    fi
+else
+    echo ""
+    echo "All Containerfiles already in sync with VERSION=$version"
+fi


### PR DESCRIPTION
## Summary

This PR implements version synchronisation tooling and build metadata labels for the bpfman repository, following the pattern established in https://github.com/openshift/bpfman-operator/pull/847.

## Changes

1. **Version synchronisation tooling**
   - Added `hack/openshift/sync-version.sh` to extract version from Cargo.toml
   - Synchronises version labels in OpenShift-specific Containerfiles
   - Added Makefile target for easy execution: `make -C hack/openshift set-version`

2. **Build metadata labels**
   - Added dynamic labels to Konflux pipeline to capture build metadata
   - Labels include: commit SHA, timestamp, source URL, and build reference
   - Provides traceability for container images back to source code

## Testing

- Tested version sync script successfully reads from `[workspace.package]` in Cargo.toml
- Verified script correctly updates version labels in Containerfile.bpfman.openshift
- Script can be run from project root using `make -C hack/openshift set-version`

## Related Work

- Follows pattern from bpfman-operator: https://github.com/openshift/bpfman-operator/pull/847