### PR TITLE
Align ystream pipelines with shared pipeline defaults

### DIFF
--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -460,7 +460,7 @@ spec:
   - default: ''
     description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
     name: image-expires-after
-  - default: 'false'
+  - default: 'true'
     description: Build a source image.
     name: build-source-image
     type: string


### PR DESCRIPTION
## Summary

Move the `build-source-image` default to the shared pipeline definition to reduce duplication and align with the pattern established in bpfman-operator.

## Changes

- Changed default value of `build-source-image` from `'false'` to `'true'` in multi-arch-build-pipeline.yaml
- This allows ystream pipeline files to inherit the correct default without explicit configuration
- The hermetic parameter remains at its default (false) as hermetic builds are not currently achievable for downstream components

## Testing

- Verified that both ystream and non-ystream pipelines will produce source images
- Follows the pattern from https://github.com/openshift/bpfman-operator/pull/876

## Additional Configuration

Also configured nudge relationships in the cluster:

```bash
oc patch component bpfman-daemon-ystream -n ocp-bpfman-tenant --type=merge -p '{"spec":{"build-nudges-ref":["bpfman-operator-bundle-ystream"]}}'
oc patch component bpfman-agent-ystream -n ocp-bpfman-tenant --type=merge -p '{"spec":{"build-nudges-ref":["bpfman-operator-bundle-ystream"]}}'
```

This ensures the operator bundle is rebuilt when the daemon or agent images are updated.