### PR TITLE
Disable legacy ocp-bpfman pipelines

### DIFF
--- a/.tekton/ocp-bpfman-pull-request.yaml
+++ b/.tekton/ocp-bpfman-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "main" && false
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman

--- a/.tekton/ocp-bpfman-push.yaml
+++ b/.tekton/ocp-bpfman-push.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "main" && false
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman


### PR DESCRIPTION
## Summary

Disable PipelinesAsCode triggers for legacy ocp-* components by adding `&& false` to their CEL expressions.

## Background

In PR #273, we discovered that disabling components with the `mintmaker.appstudio.redhat.com/disabled` annotation only prevents Mintmaker from creating PRs, but doesn't stop PipelinesAsCode from triggering builds.

To fully disable these pipelines during the transition to ystream components, we need to make the CEL expressions never match.

## Changes

- Modified `.tekton/ocp-bpfman-pull-request.yaml`: Added `&& false` to CEL expression
- Modified `.tekton/ocp-bpfman-push.yaml`: Added `&& false` to CEL expression

## Result

After this change, only ystream pipelines will run:
- ✅ `bpfman-daemon-ystream-on-pull-request` 
- ❌ `ocp-bpfman-on-pull-request` (disabled via CEL expression)

Once we're satisfied with the ystream transition, we will delete these legacy pipeline files entirely.

## Related PRs

- **Test PR that discovered the issue**: #273
- **Companion PR for bpfman-operator**: https://github.com/openshift/bpfman-operator/pull/879
- **Documentation about component management**: https://github.com/openshift/bpfman-operator/pull/878