### PR TITLE
Test: Verify only y-stream jobs run (v2)

### DIFF
--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -460,7 +460,7 @@ spec:
   - default: ''
     description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
     name: image-expires-after
-  - default: 'false'
+  - default: 'true'
     description: Build a source image.
     name: build-source-image
     type: string

--- a/test-ystream-jobs.txt
+++ b/test-ystream-jobs.txt
@@ -1,0 +1,8 @@
+Test file to verify that only y-stream jobs run after disabling the legacy ocp-* components.
+
+This demonstrates that the current CEL expressions are too broad - they trigger on ANY file change.
+We should add pathChanged() filters to only trigger on relevant source code changes.
+
+Reference: https://github.com/openshift/bpfman-operator/pull/878
+
+This file can be deleted after verification.


### PR DESCRIPTION
This is a test PR to verify that only y-stream Konflux jobs run after disabling legacy pipelines.

## Expected behaviour
- Only bpfman-daemon-ystream jobs should run
- No ocp-bpfman jobs should be triggered

## Related work
- openshift/bpfman#274 - Disabled legacy pipeline triggers
- openshift/bpfman-operator#879 - Disabled legacy pipeline triggers in operator
- openshift/bpfman#273 - Previous test PR (closed)

The legacy ocp-* pipelines have been disabled via:
1. Mintmaker annotations on the components
2. CEL expressions set to false in the pipeline files

This PR tests that the configuration is working correctly.