### PR TITLE
Fix pipeline disabling: use false instead of && false

### DIFF
--- a/.tekton/ocp-bpfman-pull-request.yaml
+++ b/.tekton/ocp-bpfman-pull-request.yaml
@@ -7,8 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && false
+    pipelinesascode.tekton.dev/on-cel-expression: "false"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman

--- a/.tekton/ocp-bpfman-push.yaml
+++ b/.tekton/ocp-bpfman-push.yaml
@@ -7,8 +7,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && false
+    pipelinesascode.tekton.dev/on-cel-expression: "false"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman


### PR DESCRIPTION
The `&& false` approach doesn't properly disable pipelines. Setting the CEL expression to just `"false"` is the correct way to disable pipelines, as verified in openshift/bpfman-operator#881.

This replaces the previous approach from PR #274 with the correct disabling method.

## Changes
- Set `pipelinesascode.tekton.dev/on-cel-expression: "false"` for both ocp-bpfman push and pull-request pipelines

## Testing
Verified this approach works in openshift/bpfman-operator#881 where only ystream pipelines run, no legacy ocp-* pipelines are triggered.

## Related PRs
- openshift/bpfman#274 - Initial attempt with `&& false` (didn't work)
- openshift/bpfman#275 - Test PR showing legacy pipelines still run with `&& false`
- openshift/bpfman-operator#879 - Correct approach with just `"false"` 
- openshift/bpfman-operator#881 - Test confirming `"false"` works