### PR TITLE
Add nudge annotation to bpfman-daemon-ystream pipeline

### DIFF
--- a/.tekton/bpfman-daemon-ystream-push.yaml
+++ b/.tekton/bpfman-daemon-ystream-push.yaml
@@ -2,6 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: hack/konflux/images/bpfman.txt
     build.appstudio.openshift.io/repo: https://github.com/openshift/bpfman?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'


### PR DESCRIPTION
## Summary

Add the missing `build.appstudio.openshift.io/build-nudge-files` annotation to `bpfman-daemon-ystream-push.yaml` to enable Konflux nudging.

## Details

The annotation points to `hack/konflux/images/bpfman.txt` which is the location for image reference updates in the bpfman-operator repository.

## Why this change is needed

When the nudge files were reorganised in bpfman-operator from `hack/update_configmap.sh` to `hack/konflux/images/`, the bpfman-daemon-ystream pipeline wasn't updated with the nudge annotation. This meant that when bpfman-daemon-ystream builds, it doesn't trigger nudge PRs in bpfman-operator.

With this change, when bpfman-daemon-ystream builds successfully, Konflux will:
1. Update `hack/konflux/images/bpfman.txt` in bpfman-operator with the new image SHA
2. Create a PR with that update
3. When merged, trigger rebuilds of dependent components (bpfman-agent-ystream and bpfman-operator-bundle-ystream)

## Related PR

- openshift/bpfman-operator#882 - Adds ystream component mirrors to ImageDigestMirrorSet