### PR TITLE
Test: Verify nudging works after annotation fix

### DIFF
--- a/hack/konflux/nudge-test.txt
+++ b/hack/konflux/nudge-test.txt
@@ -1,0 +1,1 @@
+2025-09-19: Test nudging after adding build-nudge-files annotation to bpfman-daemon-ystream


### PR DESCRIPTION
## Test PR to verify Konflux nudging

This PR adds a test file to trigger a build of bpfman-daemon-ystream and verify that nudging works after PR #277 (adding the build-nudge-files annotation).

## What to expect

Once this merges to main:
1. bpfman-daemon-ystream should build
2. If nudging is working, we should see a Konflux PR in bpfman-operator updating `hack/konflux/images/bpfman.txt`
3. That PR merging should trigger rebuilds of bpfman-agent-ystream and bpfman-operator-bundle-ystream

## Related PRs

- #277 - Adds the missing nudge annotation
- openshift/bpfman-operator#882 - Updates ImageDigestMirrorSet to include ystream components

This is similar to test PR #275.