### PR TITLE
Test: Verify nudging works post konflux-release-data MR 10491

### DIFF
--- a/hack/konflux/nudge-test.txt
+++ b/hack/konflux/nudge-test.txt
@@ -1,1 +1,2 @@
 2025-09-19: Test nudging after adding build-nudge-files annotation to bpfman-daemon-ystream
+2025-09-24: Test nudging to verify Konflux integration is working correctly


### PR DESCRIPTION
## Test PR to verify Konflux nudging post MR 10491

This PR adds a test entry to trigger a build of bpfman-daemon-ystream and verify that nudging works correctly after the changes in https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/10491

## What to expect

Once this merges to main:
1. bpfman-daemon-ystream should build
2. If nudging is working, we should see a Konflux PR in bpfman-operator updating `hack/konflux/images/bpfman.txt`
3. That PR merging should trigger rebuilds of bpfman-agent-ystream and bpfman-operator-bundle-ystream

## Related

- https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/10491 - The MR that we're testing post-merge
- #278 - Previous similar test PR

This is a test PR to ensure the Konflux integration and cross-repository nudging mechanism is functioning correctly.