### PR TITLE
tekton: temporarily build for x86_64 only to speed up pipelines

### DIFF
--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -478,9 +478,6 @@ spec:
     type: string
   - default:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
     description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
     name: build-platforms
     type: array


### PR DESCRIPTION
## Summary
- Reduced default build platforms to just linux/x86_64 to speed up pipeline builds
- This affects ystream component builds which use the pipeline defaults
- OCP builds are unaffected as they specify their own platform lists

## Purpose
This is a **temporary change** to speed up builds while transitioning to ystream components. This should be reverted once the ystream component transition is complete.

## Changes
- Modified `.tekton/multi-arch-build-pipeline.yaml` to default to x86_64 only
- Removed arm64, ppc64le, and s390x from the default platforms

## Test plan
- [ ] Verify ystream builds complete successfully with single architecture
- [ ] Confirm build times are reduced
- [ ] Ensure OCP builds still use their explicitly defined architectures