### PR TITLE
Revert "tekton: temporarily build for x86_64 only to speed up pipelines"

### DIFF
--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -478,6 +478,9 @@ spec:
     type: string
   - default:
     - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
     description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
     name: build-platforms
     type: array


### PR DESCRIPTION
## Summary
Reverting the temporary single-architecture build configuration now that the ystream component transition is complete.

## Changes
- Restores multi-architecture builds (x86_64, arm64, ppc64le, s390x)
- Reverts commit 83f1d200

This follows the same pattern as https://github.com/openshift/bpfman-operator/pull/900

## Test plan
- [ ] Verify all architectures build successfully
- [ ] Confirm ystream components continue to work with multi-arch builds