### PR TITLE
Test: Verify nudging works post ocp-bpfman component deletion

### DIFF
--- a/hack/konflux/nudge-test.txt
+++ b/hack/konflux/nudge-test.txt
@@ -1,2 +1,3 @@
 2025-09-19: Test nudging after adding build-nudge-files annotation to bpfman-daemon-ystream
 2025-09-24: Test nudging to verify Konflux integration is working correctly
+2025-09-25: Test nudging now that we've deleted ocp-bpfman* components


### PR DESCRIPTION
## Test PR to verify Konflux nudging post ocp-bpfman* component deletion

This PR adds a test entry to trigger a build of bpfman-daemon-ystream and verify that nudging works correctly after the deletion of ocp-bpfman* components.

## What to expect

Once this merges to main:
1. bpfman-daemon-ystream should build
2. If nudging is working, we should see a Konflux PR in bpfman-operator updating `hack/konflux/images/bpfman.txt`
3. That PR merging should trigger rebuilds of bpfman-agent-ystream and bpfman-operator-bundle-ystream

## Related

- #281 - Previous similar test PR