### PR TITLE
Test: Verify nudging works correctly after CEL expression fix

### DIFF
--- a/hack/konflux/nudge-test.txt
+++ b/hack/konflux/nudge-test.txt
@@ -1,3 +1,4 @@
 2025-09-19: Test nudging after adding build-nudge-files annotation to bpfman-daemon-ystream
 2025-09-24: Test nudging to verify Konflux integration is working correctly
 2025-09-25: Test nudging now that we've deleted ocp-bpfman* components
+2025-09-25: Test nudging post CEL expression fix to prevent circular builds


### PR DESCRIPTION
## Test PR to verify Konflux nudging post CEL expression fix

This PR adds a test entry to trigger a build of bpfman-daemon-ystream and verify that nudging works correctly after the CEL expression fixes in https://github.com/openshift/bpfman-operator/pull/913

## What to expect

Once this merges to main:
1. bpfman-daemon-ystream should build
2. A Konflux nudge PR should appear in bpfman-operator updating `hack/konflux/images/bpfman.txt`
3. When that nudge PR merges, it should trigger rebuilds of:
   - ✅ bpfman-agent-ystream (expected - depends on bpfman)
   - ✅ bpfman-operator-bundle-ystream (expected - packages all images)
   - ❌ **NOT** bpfman-operator-ystream (fixed - operator code hasn't changed)

## Why this test

The CEL expression fix in https://github.com/openshift/bpfman-operator/pull/913 removes the `hack/konflux/***` wildcard that was causing components to rebuild when their own image digests changed. This test verifies the fix works as intended.

## Related

- https://github.com/openshift/bpfman-operator/pull/913 - The CEL expression fix
- https://github.com/openshift/bpfman-operator/pull/912 - Previous nudge that revealed unnecessary rebuilds
- https://github.com/openshift/bpfman/pull/292 - Previous test PR