### PR TITLE
Disable Rust crate updates in renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,8 @@
 {
   "gomod": {
     "enabled": false
+  },
+  "cargo": {
+    "enabled": false
   }
 }


### PR DESCRIPTION
## Summary
This PR disables automatic Rust crate updates from Renovate/MintMaker by adding the cargo manager configuration with `enabled: false` to the existing `renovate.json` file.

## Changes
- Updated `renovate.json` to disable the cargo manager alongside the already disabled gomod manager

## Rationale
Prevents Renovate from automatically creating PRs for Rust crate dependency updates.