### PR TITLE
Add hermetic parameter to daemon pipeline configurations

### DIFF
--- a/.tekton/bpfman-daemon-ystream-pull-request.yaml
+++ b/.tekton/bpfman-daemon-ystream-pull-request.yaml
@@ -31,6 +31,8 @@ spec:
     value: Containerfile.bpfman.openshift
   - name: build-args-file
     value: OPENSHIFT-VERSION
+  - name: hermetic
+    value: 'false'
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/bpfman-daemon-ystream-push.yaml
+++ b/.tekton/bpfman-daemon-ystream-push.yaml
@@ -29,6 +29,8 @@ spec:
     value: Containerfile.bpfman.openshift
   - name: build-args-file
     value: OPENSHIFT-VERSION
+  - name: hermetic
+    value: 'false'
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/bpfman-daemon-zstream-pull-request.yaml
+++ b/.tekton/bpfman-daemon-zstream-pull-request.yaml
@@ -31,6 +31,8 @@ spec:
     value: Containerfile.bpfman.openshift
   - name: build-args-file
     value: OPENSHIFT-VERSION
+  - name: hermetic
+    value: 'false'
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/bpfman-daemon-zstream-push.yaml
+++ b/.tekton/bpfman-daemon-zstream-push.yaml
@@ -29,6 +29,8 @@ spec:
     value: Containerfile.bpfman.openshift
   - name: build-args-file
     value: OPENSHIFT-VERSION
+  - name: hermetic
+    value: 'false'
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:


### PR DESCRIPTION
## Summary

Explicitly set the hermetic parameter to 'false' in all daemon pipeline configurations (ystream and zstream, push and pull-request) to satisfy Enterprise Contract policy requirements.

## Problem

The EC policy violation occurs when the hermetic parameter is not explicitly passed to the buildah-remote-oci-ta task, even though the pipeline default is 'false'. The policy requires explicit acknowledgment at the PipelineRun level for non-hermetic builds.

## Solution

By explicitly setting `hermetic: 'false'`, the task is invoked with the parameter set (satisfying the policy check), whilst allowing non-hermetic builds under the existing volatileConfig exception ([KFLUXSPRT-4436](https://issues.redhat.com/browse/KFLUXSPRT-4436), valid until 2025-12-31).

## Changes

- Add `hermetic: 'false'` parameter to `.tekton/bpfman-daemon-ystream-push.yaml`
- Add `hermetic: 'false'` parameter to `.tekton/bpfman-daemon-ystream-pull-request.yaml`
- Add `hermetic: 'false'` parameter to `.tekton/bpfman-daemon-zstream-push.yaml`
- Add `hermetic: 'false'` parameter to `.tekton/bpfman-daemon-zstream-pull-request.yaml`

## Context

This restores similar configuration that was previously present in the ocp-bpfman component (before it was purged in 961a42f) and replaced with the bpfman-daemon-ystream and bpfman-daemon-zstream components.

The daemon builds will remain non-hermetic as permitted by the exception in konflux-release-data due to:
1. sigstore-rs FIPS issues on s390x/ppc64le architectures requiring runtime dependency resolution
2. Rust edition 2024 requirements not supported in RHEL 9.6

Reference: https://issues.redhat.com/browse/KFLUXSPRT-4436