### PR TITLE
Add pathChanged triggers to daemon pipeline configurations

### DIFF
--- a/.tekton/bpfman-daemon-ystream-pull-request.yaml
+++ b/.tekton/bpfman-daemon-ystream-pull-request.yaml
@@ -9,7 +9,10 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "main" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-daemon-ystream-pull-request.yaml".pathChanged()
+      || ".tekton/bpfman-daemon-ystream-push.yaml".pathChanged() || "Containerfile.bpfman.openshift".pathChanged()
+      || "Cargo.toml".pathChanged() || "Cargo.lock".pathChanged() || "src/***".pathChanged()
+      || "hack/konflux/images/bpfman.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream

--- a/.tekton/bpfman-daemon-ystream-push.yaml
+++ b/.tekton/bpfman-daemon-ystream-push.yaml
@@ -9,7 +9,10 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "main" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-daemon-ystream-pull-request.yaml".pathChanged()
+      || ".tekton/bpfman-daemon-ystream-push.yaml".pathChanged() || "Containerfile.bpfman.openshift".pathChanged()
+      || "Cargo.toml".pathChanged() || "Cargo.lock".pathChanged() || "src/***".pathChanged()
+      || "hack/konflux/images/bpfman.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-ystream

--- a/.tekton/bpfman-daemon-zstream-pull-request.yaml
+++ b/.tekton/bpfman-daemon-zstream-pull-request.yaml
@@ -9,7 +9,10 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "release-4.20"
+      == "release-4.20" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-daemon-zstream-pull-request.yaml".pathChanged()
+      || ".tekton/bpfman-daemon-zstream-push.yaml".pathChanged() || "Containerfile.bpfman.openshift".pathChanged()
+      || "Cargo.toml".pathChanged() || "Cargo.lock".pathChanged() || "src/***".pathChanged()
+      || "hack/konflux/images/bpfman.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-zstream

--- a/.tekton/bpfman-daemon-zstream-push.yaml
+++ b/.tekton/bpfman-daemon-zstream-push.yaml
@@ -9,7 +9,10 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release-4.20"
+      == "release-4.20" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/bpfman-daemon-zstream-pull-request.yaml".pathChanged()
+      || ".tekton/bpfman-daemon-zstream-push.yaml".pathChanged() || "Containerfile.bpfman.openshift".pathChanged()
+      || "Cargo.toml".pathChanged() || "Cargo.lock".pathChanged() || "src/***".pathChanged()
+      || "hack/konflux/images/bpfman.txt".pathChanged() || "OPENSHIFT-VERSION".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: bpfman-zstream


### PR DESCRIPTION
## Summary

Add CEL expressions to daemon pipeline triggers to watch for changes in files that affect the daemon builds.

## Problem

Currently, the daemon pipelines trigger on all pushes/PRs to main or release-4.20 branches without filtering for relevant file changes. This means:
1. Changes to unrelated files trigger unnecessary daemon builds
2. More critically, changes to OPENSHIFT-VERSION or other build-affecting files don't get filtered properly

## Solution

Add `pathChanged()` CEL expressions that monitor:
- Pipeline definitions (`.tekton/multi-arch-build-pipeline.yaml`, `.tekton/bpfman-daemon-*-*.yaml`)
- `Containerfile.bpfman.openshift`
- Rust dependencies (`Cargo.toml`, `Cargo.lock`)
- Source code (`src/***`)
- Nudge file (`hack/konflux/images/bpfman.txt`)
- **`OPENSHIFT-VERSION`** - ensures version bumps trigger new builds with updated labels

## Changes

- Add pathChanged() CEL expressions to:
  - `.tekton/bpfman-daemon-ystream-push.yaml`
  - `.tekton/bpfman-daemon-ystream-pull-request.yaml`
  - `.tekton/bpfman-daemon-zstream-push.yaml`
  - `.tekton/bpfman-daemon-zstream-pull-request.yaml`

## Context

This follows the pattern used in bpfman-operator pipelines, which already have similar CEL expressions to filter builds based on relevant file changes.