### PR TITLE
Remove hermetic parameter default from pipeline definition

### DIFF
--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -453,8 +453,7 @@ spec:
     description: Skip checks against built image
     name: skip-checks
     type: string
-  - default: 'false'
-    description: Execute the build with network isolation
+  - description: Execute the build with network isolation
     name: hermetic
     type: string
   - default: ''


### PR DESCRIPTION
## Summary

Remove the default value of 'false' for the hermetic parameter in the multi-arch build pipeline.

## Problem

The default is effectively useless: it doesn't satisfy the Enterprise Contract policy requirement even though the builds would technically use that default value. The Enterprise Contract policy requires explicit parameter presence at the PipelineRun level, not the effective value that would be used.

This means:
- Without explicit `hermetic: 'false'` in the PipelineRun → EC policy violation (even though the build uses the default 'false')
- With explicit `hermetic: 'false'` in the PipelineRun → EC policy passes

Therefore the default serves no practical purpose for EC compliance. You always have to explicitly set it anyway, making the default declaration pointless.

## Analysis

It's backwards design:
- Defaults exist to reduce boilerplate
- Policy requires the boilerplate anyway
- Therefore defaults serve no purpose except to confuse people about what's actually required

It creates operational friction:
- Developers assume defaults work (reasonable expectation)
- Builds fail with obscure EC policy violations
- Investigation reveals you must explicitly set what's already the default
- Wasted time debugging what should have "just worked"

The correct solutions would be:
1. Make the policy check the **effective value** (default or explicit), not require explicit specification
2. Or remove the defaults entirely if explicit specification is mandatory

This change implements the latter: removing misleading defaults that create the false impression they satisfy policy requirements.

## Changes

- Remove `default: 'false'` from hermetic parameter in `.tekton/multi-arch-build-pipeline.yaml`

The hermetic parameter is now required to be explicitly specified in all PipelineRun definitions.

## Context

PR #326 already added explicit `hermetic: 'false'` to all daemon PipelineRuns, so this change is safe to merge.

See also openshift/bpfman-operator#1064 which removes the same useless default (though set to 'true' in that repo) after openshift/bpfman-operator#1063 added explicit hermetic parameters to all operator/agent/bundle PipelineRuns.