### PR TITLE
Test daemon build nudge mechanism after PR #326

### DIFF
--- a/test-nudge-trigger-2.txt
+++ b/test-nudge-trigger-2.txt
@@ -1,0 +1,11 @@
+This is a test file to trigger daemon builds after PR #326 merged.
+
+The builds need to pick up the hermetic: 'false' parameter that was
+added in PR #326 to satisfy Enterprise Contract policy requirements.
+
+Previous builds were failing EC validation with:
+  Violation: hermetic_task.hermetic
+  Reason: Task 'buildah-remote-oci-ta' was not invoked with the hermetic parameter set
+
+This dummy commit should trigger fresh daemon builds with the correct
+parameters.


### PR DESCRIPTION
Trigger daemon builds to pick up the hermetic: 'false' parameter added in PR #326.

Previous builds were failing Enterprise Contract validation with:
```
Violation: hermetic_task.hermetic
Reason: Task 'buildah-remote-oci-ta' was not invoked with the hermetic parameter set
```

This dummy commit triggers fresh daemon builds with the correct parameters to satisfy EC policy requirements.