### PR TITLE
Test daemon build nudge mechanism (attempt 3)

### DIFF
--- a/test-nudge-trigger-3.txt
+++ b/test-nudge-trigger-3.txt
@@ -1,0 +1,6 @@
+Third test file to trigger daemon builds after PR #326.
+
+Previous build failed with CouldntGetTask - Konflux infrastructure issue.
+
+This dummy commit triggers fresh daemon builds with the hermetic: 'false'
+parameter required by Enterprise Contract policy.


### PR DESCRIPTION
Previous build failed with CouldntGetTask infrastructure error.

Trigger fresh daemon builds to pick up the hermetic: 'false' parameter added in PR #326 for Enterprise Contract policy compliance.