### PR TITLE
Test daemon build nudge mechanism (attempt 4)

### DIFF
--- a/test-nudge-trigger-4.txt
+++ b/test-nudge-trigger-4.txt
@@ -1,0 +1,11 @@
+Test daemon build nudge mechanism (attempt 4)
+
+This change validates the end-to-end nudging flow after the pipeline fixes in bpfman-operator PR #1097.
+
+Expected flow:
+1. Daemon builds trigger with this change
+2. Daemon nudges operator via hack/konflux/images/bpfman.txt
+3. Operator rebuilds
+4. Operator nudges bundle via hack/konflux/images/bpfman-operator.txt
+5. Bundle rebuilds
+6. Snapshot created with consistent component versions


### PR DESCRIPTION
## Summary

This PR validates the end-to-end nudging flow after the pipeline fixes implemented in bpfman-operator PR #1097.

The change triggers daemon component builds in konflux, which should cascade through the operator to the bundle, creating a consistent snapshot.

## Expected Flow

1. Daemon component builds with this change
2. Daemon nudges operator via `hack/konflux/images/bpfman.txt` update  
3. Operator rebuilds due to daemon nudge file trigger
4. Operator nudges bundle via `hack/konflux/images/bpfman-operator.txt`
5. Bundle rebuilds with all current component references
6. Release snapshot created with consistent component versions

## Validation Goal

This validates that the synchronisation point established in PR #1097 prevents the race condition that caused inconsistent snapshots in releases wcq24 and 6qmdv.

## Related

- bpfman-operator PR #1097: Pipeline fixes to route component updates through operator
- Previous test: PR #331