### PR TITLE
Pin UBI base image to digest and refresh RPM lockfile (release-0.6)

### DIFF
--- a/Containerfile.bpfman.openshift
+++ b/Containerfile.bpfman.openshift
@@ -1,6 +1,6 @@
 ARG BUILDVERSION
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS bpfman-build
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:5b74fce9d6e629942a0c6dc0f546c193e70d7f974d999a48c948c53dd3d36362 AS bpfman-build
 ARG BUILDVERSION
 ARG BUILD_COMMIT
 
@@ -19,7 +19,7 @@ RUN : "${BUILD_COMMIT:=$(git rev-parse --short=10 HEAD 2>/dev/null || echo unkno
     export BPFMAN_BUILD_INFO="${BUILDVERSION} (${BUILD_COMMIT} ${BUILD_DATE}) ${RUSTC_VERSION}" && \
     cargo build --release
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:5b74fce9d6e629942a0c6dc0f546c193e70d7f974d999a48c948c53dd3d36362
 
 ARG BUILDVERSION
 ARG CPE_VERSION

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -158,13 +158,13 @@ arches:
     name: gcc-toolset-15-runtime
     evr: 15.0-9.el9
     sourcerpm: gcc-toolset-15-15.0-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/g/glibc-devel-2.34-266.el9_8.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/g/glibc-devel-2.34-270.el9_8.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 577601
-    checksum: sha256:5ffa33b3054faa784aa531c617b78cee587b2c365f8a6ac227ab6cb55da70bcb
+    size: 578011
+    checksum: sha256:dc745c58066e323f08bdc8b613163c59899e764eed95899afa64d58b424c5a57
     name: glibc-devel
-    evr: 2.34-266.el9_8
-    sourcerpm: glibc-2.34-266.el9_8.src.rpm
+    evr: 2.34-270.el9_8
+    sourcerpm: glibc-2.34-270.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-687.10.1.el9_8.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 2798909
@@ -932,13 +932,13 @@ arches:
     name: gcc-toolset-15-runtime
     evr: 15.0-9.el9
     sourcerpm: gcc-toolset-15-15.0-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/g/glibc-devel-2.34-266.el9_8.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/g/glibc-devel-2.34-270.el9_8.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-appstream-rpms
-    size: 588615
-    checksum: sha256:a5cd394872d03cad1275fd9f2598e80c8111e257a6870262cc6fc33cac8b9de6
+    size: 588949
+    checksum: sha256:d9f77ee546f6fb00410aba8f6211df271515f3601de604ce38ba5e57c8c0944d
     name: glibc-devel
-    evr: 2.34-266.el9_8
-    sourcerpm: glibc-2.34-266.el9_8.src.rpm
+    evr: 2.34-270.el9_8
+    sourcerpm: glibc-2.34-270.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/k/kernel-headers-5.14.0-687.10.1.el9_8.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 2822733
@@ -1713,20 +1713,20 @@ arches:
     name: gcc-toolset-15-runtime
     evr: 15.0-9.el9
     sourcerpm: gcc-toolset-15-15.0-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/g/glibc-devel-2.34-266.el9_8.s390x.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/g/glibc-devel-2.34-270.el9_8.s390x.rpm
     repoid: rhel-9-for-s390x-appstream-rpms
-    size: 54861
-    checksum: sha256:214b0067655eb3a508109ae7686a41c5d6d875348821262aa9550912e193a847
+    size: 55236
+    checksum: sha256:005bbfb5939c2affb600736d72f1d3807d641708a5aa454aa45672ae563fe874
     name: glibc-devel
-    evr: 2.34-266.el9_8
-    sourcerpm: glibc-2.34-266.el9_8.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/g/glibc-headers-2.34-266.el9_8.s390x.rpm
+    evr: 2.34-270.el9_8
+    sourcerpm: glibc-2.34-270.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/g/glibc-headers-2.34-270.el9_8.s390x.rpm
     repoid: rhel-9-for-s390x-appstream-rpms
-    size: 558502
-    checksum: sha256:239dd18a080a335abeb116c90b797a56fdd0709a8d120836b7e96e6b6c3d5dc6
+    size: 558813
+    checksum: sha256:90640d9701d7f880d6330fb83bc87ee8cf7c8d9e3ecebcb905a54717b693edc5
     name: glibc-headers
-    evr: 2.34-266.el9_8
-    sourcerpm: glibc-2.34-266.el9_8.src.rpm
+    evr: 2.34-270.el9_8
+    sourcerpm: glibc-2.34-270.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/k/kernel-headers-5.14.0-687.10.1.el9_8.s390x.rpm
     repoid: rhel-9-for-s390x-appstream-rpms
     size: 2828909
@@ -2494,20 +2494,20 @@ arches:
     name: gcc-toolset-15-runtime
     evr: 15.0-9.el9
     sourcerpm: gcc-toolset-15-15.0-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/glibc-devel-2.34-266.el9_8.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/glibc-devel-2.34-270.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 47101
-    checksum: sha256:9cce153edd234a16deb0c5a981f73fa2b5a6d7b42b5fb9e1f4a010612318d408
+    size: 47451
+    checksum: sha256:ac596cb6c59f74558e4b9b3674abc34d79c9772c4165f5cda866c1c24c81f939
     name: glibc-devel
-    evr: 2.34-266.el9_8
-    sourcerpm: glibc-2.34-266.el9_8.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/glibc-headers-2.34-266.el9_8.x86_64.rpm
+    evr: 2.34-270.el9_8
+    sourcerpm: glibc-2.34-270.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/glibc-headers-2.34-270.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 567846
-    checksum: sha256:9dbaaaec43b9fc78ce26b660e75081c5de09245d7431a77c3f0c47ae0b657c9d
+    size: 568001
+    checksum: sha256:0eab0982c27442a8e4acbd7b32a66757174482dcc183ef27412427f54f8f36d7
     name: glibc-headers
-    evr: 2.34-266.el9_8
-    sourcerpm: glibc-2.34-266.el9_8.src.rpm
+    evr: 2.34-270.el9_8
+    sourcerpm: glibc-2.34-270.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-687.10.1.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 2838185


### PR DESCRIPTION
The hermetic build on release-0.6 broke a few hours after the previous lockfile refresh because `registry.access.redhat.com/ubi9/ubi-minimal:latest` was rebuilt with a newer 9.8 z-stream glibc. The lockfile still pinned `glibc-devel-2.34-266.el9_8` while the new base image carried `glibc-2.34-270.el9_8` installed, so the `microdnf install` step in `Containerfile.bpfman.openshift` could no longer depsolve `glibc-devel` against either the prefetched RPMs or the new base, and the build failed across all four arches with `nothing provides glibc = 2.34-266.el9_8`.

This pins both `FROM` lines in `Containerfile.bpfman.openshift` to the current `ubi-minimal:latest` digest (`sha256:5b74fce9d6e629942a0c6dc0f546c193e70d7f974d999a48c948c53dd3d36362`, label version 9.8, release 1779809423, built 2026-05-26 15:32 UTC) and regenerates `rpms.lock.yaml` against the same pin. `rpms.in.yaml` derives the base image from this Containerfile's `bpfman-build` stage, so the digest becomes the single source of truth for both runtime and lockfile resolution. With the digest pinned, the base image only rolls forward when mintmaker bumps it, and each bump can ship a matching lockfile refresh in the same PR rather than the two drifting independently between Red Hat's tag rebuilds.

The only package churn in the lockfile is `glibc-devel` and `glibc-headers` moving from `2.34-266.el9_8` to `2.34-270.el9_8` across `aarch64`, `ppc64le`, `s390x`, and `x86_64` (30 insertions, 30 deletions). The same fix needs to land on `main` in a follow-up; `downstream/main` has the identical lockfile shape and is one UBI rebuild away from the same failure.

## Test plan

- [ ] Konflux `bpfman-daemon-zstream-on-pull-request` build succeeds (this is exactly the check that has been failing on #649 and #657 with the `nothing provides glibc = 2.34-266.el9_8` depsolve error).
- [ ] Enterprise contract check passes.
- [ ] After merge, confirm mintmaker proposes a digest bump the next time `ubi-minimal:latest` rebuilds, and that the bump PR also refreshes `rpms.lock.yaml`. If it does not, follow up with explicit Renovate `customManagers` config rather than relying on the Docker-manager default file pattern matching `Containerfile.bpfman.openshift`.